### PR TITLE
remove cloning and _rev removal, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ API
 
 Perform an upsert (update or insert) operation. If you don't specify a `callback`, then this function returns a Promise.
 
-* `docId` - the `_id` of the document
-* `diffFunc` - function that takes the existing doc (minus the `_rev` property) as input and returns an updated doc. If this function returns falsey, then the update won't be performed (as an optimization). If the document does not already exist then `{}` will be the input to `diffFunc`.
+* `docId` - the `_id` of the document.
+* `diffFunc` - function that takes the existing doc as input and returns an updated doc.
+  * If this `diffFunc` returns falsey, then the update won't be performed (as an optimization).
+  * If the document does not already exist, then `{}` will be the input to `diffFunc`.
 
 ##### Example 1
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PouchDB Upsert
 
 A tiny plugin for PouchDB that provides two convenience methods:
 
-* `upsert()` - update a document, or insert a new one if it doesn't exist ("upsert"). Will keep retrying if it gets 409 conflicts.
+* `upsert()` - update a document, or insert a new one if it doesn't exist ("upsert"). Will keep retrying (forever) if it gets 409 conflicts.
 * `putIfNotExists()` - create a new document if it doesn't exist. Does nothing if it already exists.
 
 So basically, if you're tired of manually dealing with 409s or 404s in your PouchDB code, then this is the plugin for you.
@@ -53,7 +53,7 @@ API
 Perform an upsert (update or insert) operation. If you don't specify a `callback`, then this function returns a Promise.
 
 * `docId` - the `_id` of the document
-* `diffFunc` - function that takes the existing/new doc as input and returns an updated doc. If this function returns falsey, then the update won't be performed (as an optimization)
+* `diffFunc` - function that takes the existing doc as input and returns an updated doc. If this function returns falsey, then the update won't be performed (as an optimization). If the document does not already exist then `{}` will be the input to `diffFunc`.
 
 ##### Example 1
 
@@ -95,7 +95,7 @@ Resulting doc (after 3 `upsert`s):
 
 ##### Example 2
 
-A `diffFunc` that ony updates the doc if it's missing a certain field:
+A `diffFunc` that only updates the doc if it's missing a certain field:
 
 ```js
 db.upsert('myDocId', function (doc) {
@@ -218,7 +218,7 @@ Testing
 This will run the tests in Node using LevelDB:
 
     npm test
-    
+
 You can also check for 100% code coverage using:
 
     npm run coverage

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ API
 Perform an upsert (update or insert) operation. If you don't specify a `callback`, then this function returns a Promise.
 
 * `docId` - the `_id` of the document
-* `diffFunc` - function that takes the existing doc as input and returns an updated doc. If this function returns falsey, then the update won't be performed (as an optimization). If the document does not already exist then `{}` will be the input to `diffFunc`.
+* `diffFunc` - function that takes the existing doc (minus the `_rev` property) as input and returns an updated doc. If this function returns falsey, then the update won't be performed (as an optimization). If the document does not already exist then `{}` will be the input to `diffFunc`.
 
 ##### Example 1
 

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   },
   "dependencies": {
     "es3ify": "^0.1.3",
-    "lie": "^2.6.0",
-    "lodash.clone": "^3.0.1"
+    "lie": "^2.6.0"
   },
   "devDependencies": {
     "bluebird": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "coverage": "npm test --coverage && istanbul check-coverage --lines 100 --function 100 --statements 100 --branches 100"
   },
   "dependencies": {
+    "es3ify": "^0.1.3",
     "lie": "^2.6.0",
-    "es3ify": "^0.1.3"
+    "lodash.clone": "^3.0.1"
   },
   "devDependencies": {
     "bluebird": "^1.0.7",


### PR DESCRIPTION
My proposed version of https://github.com/pouchdb/pouchdb-upsert/pull/3.

As it turned out, I didn't even need `pouchdb-extend` for cloning, because the tests can pass without any cloning, which is a win for performance.

I also decided to formalize how I think the `_rev`/`_id` system ought to work:

* a `{}` object gets passed in to the `diffFunc` the first time (as described in the README now, thanks @slang800)
* `_rev`/`_id` gets passed in after that

I think this is the most logical, given that you're seeing the object exactly as it was `get()`ted from the database (except in the case of `{}`, which is a little odd but still acceptable IMO).

