### PR TITLE
catch errors thrown in diff function

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -373,5 +373,15 @@ function tests(dbName, dbType) {
       });
     });
 
+    it('errors thrown in diff function shouldn\'t crash the system', function () {
+      return db.upsert('foo', function () {
+        throw new Error("An upsert diff error.");
+      }).then(function () {
+        throw new Error("Finished upsert without throwing error.");
+      }, function (e) {
+        should.exist(e);
+      });
+    });
+
   });
 }


### PR DESCRIPTION
I noticed that errors being thrown in the diff function were crashing my program. I moved the upsert logic from the `get()` callback into a Promise chain. This fixed the issue and made the code a bit cleaner, IMO.