### PR TITLE
chore(package): update pouchdb-promise to version 6.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "coverage": "npm test --coverage && istanbul check-coverage --lines 100 --function 100 --statements 100 --branches 100"
   },
   "dependencies": {
-    "pouchdb-promise": "^6.1.2"
+    "pouchdb-promise": "^6.4.3"
   },
   "devDependencies": {
     "bluebird": "^3.4.7",


### PR DESCRIPTION
Because of using earlier version of pouchdb-promise this error happens when doc._id not provided: PouchPromise.reject is not a function